### PR TITLE
fix(#36): 캐러셀 무한루프 수정 및 slide button 개수 수정

### DIFF
--- a/src/components/projectDetail/Carousel.tsx
+++ b/src/components/projectDetail/Carousel.tsx
@@ -11,6 +11,11 @@ export default function Carousel() {
   const { data } = useContext(ProjectDetailContext);
   const [currentImg, setCurrentImg] = useState<number>(0);
 
+  const slides =
+    data.category.projectinfo.carousel.length <= 2
+      ? [...data.category.projectinfo.carousel, ...data.category.projectinfo.carousel]
+      : data.category.projectinfo.carousel;
+
   const onSelect = useCallback(() => {
     if (!emblaApi) return;
     setCurrentImg(emblaApi.selectedScrollSnap());
@@ -26,12 +31,12 @@ export default function Carousel() {
     <s.Section>
       <s.PrevButton
         onClick={() => {
-          emblaApi?.scrollNext();
+          emblaApi?.scrollPrev();
         }}
       />
       <s.CarouselViewport ref={emblaRef}>
         <s.CarouselContainer>
-          {data.category.projectinfo.carousel.map((carouselObj, key) => {
+          {slides.map((carouselObj, key) => {
             if (carouselObj.type == 'video') {
               return (
                 <s.CarouselSlide key={carouselObj.img + key}>
@@ -48,23 +53,26 @@ export default function Carousel() {
               return (
                 <s.CarouselSlide key={carouselObj.img + key}>
                   <s.Img src={`/public/${carouselObj.img}`} alt="" $type={carouselObj.type} />
-                  {/* imgType={carouselObj.type} */}
                 </s.CarouselSlide>
               );
             }
           })}
         </s.CarouselContainer>
         <s.ButtonSection>
-          {data.category.projectinfo.carousel.map((carouselObj, index) => (
-            <s.SlideButton
-              aria-label="btn"
-              key={index}
-              $bgColor={currentImg == index ? 'color' : 'none'}
-              onClick={() => {
-                emblaApi?.scrollTo(index);
-              }}
-            ></s.SlideButton>
-          ))}
+          {slides.map((carouselObj, index) => {
+            if (index < slides.length / 2) {
+              return (
+                <s.SlideButton
+                  aria-label="btn"
+                  key={index}
+                  $bgColor={currentImg == index ? 'color' : 'none'}
+                  onClick={() => {
+                    emblaApi?.scrollTo(index);
+                  }}
+                ></s.SlideButton>
+              );
+            }
+          })}
         </s.ButtonSection>
       </s.CarouselViewport>
       <s.NextButton


### PR DESCRIPTION
## fix(#36): 캐러셀 무한루프 수정 및 slide button 개수 수정

## :pencil:작업 내용
- 캐러셀 무한 루프
  캐러셀 사진이 2장 이하일 때 사진이 들어있는 배열을 복제해 실질적으로 렌더링 되는 사진 개수를 두배로 만들어 무한 루프 적용

- 슬라이드 버튼 개수 수정
  캐러셀에서 한번에 이미지를 2장씩 보여주기 때문에 슬라이드 버튼 수를 사진 배열 길이 / 2한 값만큼 렌더링