### PR TITLE
fix(#37): 프로젝트 클릭 시 페이지 상단부로 이동

### DIFF
--- a/src/components/projectGallery/GalleryBanner.tsx
+++ b/src/components/projectGallery/GalleryBanner.tsx
@@ -1,9 +1,10 @@
+import React from 'react';
 import { ReactComponent as Banner } from '../../assets/svg/ProjectGalleryBanner.svg';
 import * as s from '../../style/ProjectGallery/GalleryBannerStyle';
 
-export default function ProjectInfo() {
+export default function ProjectInfo({ TopRef }: { TopRef: React.RefObject<HTMLDivElement> }) {
   return (
-    <s.Section>
+    <s.Section ref={TopRef}>
       <Banner />
       <s.TextBox>
         <s.HighlightText>링크 하나로 끝나는 쉬운 프로젝트 홍보!</s.HighlightText>

--- a/src/components/projectGallery/ProjectCollection.tsx
+++ b/src/components/projectGallery/ProjectCollection.tsx
@@ -4,7 +4,7 @@ import { ProjectGalleryData } from '../../interface';
 import * as s from '../../style/ProjectGallery/ProjectCollectionStyle';
 import { useNavigate } from 'react-router-dom';
 
-export default function ProjectCollection() {
+export default function ProjectCollection({ TopRef }: { TopRef: React.RefObject<HTMLDivElement> }) {
   const [project, updateProject] = useImmer<ProjectGalleryData>({
     data: [],
   });
@@ -18,6 +18,7 @@ export default function ProjectCollection() {
         <s.Project
           key={index}
           onClick={() => {
+            TopRef.current?.scrollIntoView({ behavior: 'smooth' });
             navigate(projectObj.param.toLowerCase());
           }}
         >

--- a/src/page/ProjectGallery.tsx
+++ b/src/page/ProjectGallery.tsx
@@ -1,3 +1,4 @@
+import React, { useRef } from 'react';
 import Footer from '../components/common/Footer';
 import Header from '../components/common/Header';
 import ProjectInfo from '../components/projectGallery/GalleryBanner';
@@ -5,12 +6,13 @@ import ProjectCollection from '../components/projectGallery/ProjectCollection';
 import * as s from '../style/projectDetail/ProjectDetailsStyle';
 
 export default function ProjectGallery() {
+  const TopRef = useRef<HTMLDivElement>(null);
   return (
     <>
       <Header />
       <s.Main>
-        <ProjectInfo />
-        <ProjectCollection />
+        <ProjectInfo TopRef={TopRef} />
+        <ProjectCollection TopRef={TopRef} />
       </s.Main>
       <Footer />
     </>


### PR DESCRIPTION
## fix(#37): 프로젝트 클릭 시 페이지 상단부로 이동

## :pencil:작업 내용
- 프로젝트 클릭 시 페이지 상단으로 이동
  수정 전
     프로젝트 전체보기 아래쪽에 위치한 프로젝트를 클릭해 상세페이지로 이동시 이전 전체보기 페이지 스크롤 위치 그대로 상세페이지로 이동
 
  수정 후
     프로젝트 클릭 후 상세페이지로 이동시 상세페이지 맨 위로 이동