### PR TITLE
fix(#37): ref 적용 위치 헤더로 변경

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -2,10 +2,10 @@ import * as s from '../../style/common/HeaderStyle';
 import { ReactComponent as ProjectIcon } from '../../assets/svg/ProjectIcon.svg';
 import { useNavigate } from 'react-router-dom';
 
-export default function Header() {
+export default function Header({ TopRef }: { TopRef?: React.RefObject<HTMLDivElement> }) {
   const navigate = useNavigate();
   return (
-    <s.Header>
+    <s.Header ref={TopRef}>
       <s.NavigationBox width={353}>
         <s.Logo />
         <s.Nav>

--- a/src/components/projectGallery/GalleryBanner.tsx
+++ b/src/components/projectGallery/GalleryBanner.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
 import { ReactComponent as Banner } from '../../assets/svg/ProjectGalleryBanner.svg';
 import * as s from '../../style/ProjectGallery/GalleryBannerStyle';
 
-export default function ProjectInfo({ TopRef }: { TopRef: React.RefObject<HTMLDivElement> }) {
+export default function ProjectInfo() {
   return (
-    <s.Section ref={TopRef}>
+    <s.Section>
       <Banner />
       <s.TextBox>
         <s.HighlightText>링크 하나로 끝나는 쉬운 프로젝트 홍보!</s.HighlightText>

--- a/src/page/ProjectGallery.tsx
+++ b/src/page/ProjectGallery.tsx
@@ -9,9 +9,9 @@ export default function ProjectGallery() {
   const TopRef = useRef<HTMLDivElement>(null);
   return (
     <>
-      <Header />
+      <Header TopRef={TopRef} />
       <s.Main>
-        <ProjectInfo TopRef={TopRef} />
+        <ProjectInfo />
         <ProjectCollection TopRef={TopRef} />
       </s.Main>
       <Footer />


### PR DESCRIPTION
## fix(#37): ref 적용 위치 헤더로 변경

## :pencil:작업 내용
- ref를 프로젝트 전체보기 페이지에 적용하니 페이지 최상단까지 이동하는게 아닌 헤더 아래까지만 이동해서 ref 헤더에 적용