### PR TITLE
refactor(#51): 프로젝트 전체보기 페이지 가로 스크롤 hidden 적용

### DIFF
--- a/src/style/GlobalStyle.tsx
+++ b/src/style/GlobalStyle.tsx
@@ -22,6 +22,7 @@ export const GlobalStyle = createGlobalStyle`
   #root{
     width: 100%;
     height: 100%;
+    overflow-x: hidden;
   }
 
   ::-webkit-scrollbar {

--- a/src/style/ProjectGallery/GalleryBannerStyle.tsx
+++ b/src/style/ProjectGallery/GalleryBannerStyle.tsx
@@ -7,7 +7,6 @@ export const Section = styled.section`
   align-items: center;
   justify-content: center;
   margin-left: calc(-50vw + 50%);
-  overflow-x: hidden;
 `;
 
 export const TextBox = styled.div`


### PR DESCRIPTION
## refactor(#51): 프로젝트 전체보기 페이지 가로 스크롤 hidden 적용

## :pencil:작업 내용
배너 이미지 사용으로 인해 width를 100vw까지 늘려놔서 가로 스크롤 생김
- width: 100vw 말고 svg 파일을 화면에 딱 맞출 방법이 없어서 #root 에 overflow-hidden 적용