### PR TITLE
refactor(#58): 프로젝트 전체보기 css 수정

### DIFF
--- a/src/page/ProjectDetails.tsx
+++ b/src/page/ProjectDetails.tsx
@@ -12,7 +12,7 @@ export default function ProjectDetails() {
   return (
     <>
       <Header />
-      <s.Main>
+      <s.Main $overflow="none">
         <ProjectDetailProvider>
           <CategoryProvider>
             <s.Div>

--- a/src/page/ProjectGallery.tsx
+++ b/src/page/ProjectGallery.tsx
@@ -10,7 +10,7 @@ export default function ProjectGallery() {
   return (
     <>
       <Header TopRef={TopRef} />
-      <s.Main>
+      <s.Main $overflow="hidden">
         <ProjectInfo />
         <ProjectCollection TopRef={TopRef} />
       </s.Main>

--- a/src/style/GlobalStyle.tsx
+++ b/src/style/GlobalStyle.tsx
@@ -22,7 +22,6 @@ export const GlobalStyle = createGlobalStyle`
   #root{
     width: 100%;
     height: 100%;
-    overflow-x: hidden;
   }
 
   ::-webkit-scrollbar {

--- a/src/style/ProjectGallery/ProjectCollectionStyle.tsx
+++ b/src/style/ProjectGallery/ProjectCollectionStyle.tsx
@@ -18,7 +18,7 @@ export const Project = styled.div`
   cursor: pointer;
 `;
 
-export const ProjectName = styled.span`
+export const ProjectName = styled.p`
   color: #47484c;
   font-size: 14px;
   font-weight: 500;

--- a/src/style/ProjectGallery/ProjectCollectionStyle.tsx
+++ b/src/style/ProjectGallery/ProjectCollectionStyle.tsx
@@ -4,17 +4,17 @@ export const Section = styled.section`
   padding: 32px 0px;
   width: 100%;
   display: flex;
+  justify-content: center;
   flex-wrap: wrap;
   gap: 48px;
 `;
 
 export const Project = styled.div`
-  width: 253px;
+  width: 15vw;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   gap: 12px;
-  flex: 1 0 0;
   cursor: pointer;
 `;
 
@@ -35,7 +35,7 @@ export const Description = styled.p`
 `;
 
 export const Img = styled.img`
-  width: 19vw;
-  height: 19vw;
+  width: 15vw;
+  height: 15vw;
   border-radius: 12px;
 `;

--- a/src/style/common/FooterStyle.tsx
+++ b/src/style/common/FooterStyle.tsx
@@ -3,13 +3,15 @@ import { ReactComponent as InstargramIcon } from '../../assets/svg/InstargramNon
 import { ReactComponent as LinkedInIcon } from '../../assets/svg/LinkedIn.svg';
 
 export const Footer = styled.footer`
-  padding: 40px 20px 24px 20px;
+  padding: 0 170px;
   width: 100%;
   height: 292px;
+  border-top: 1px solid #cfebff;
   box-sizing: border-box;
 `;
 
 export const TopSection = styled.section`
+  padding: 40px 20px 32px 20px;
   width: 100%;
   height: 54px;
   display: flex;
@@ -46,7 +48,7 @@ export const Menu = styled.span`
 `;
 
 export const MidSection = styled.section`
-  margin: 32px 0;
+  padding: 0px 20px 32px 20px;
   width: 100%;
   height: 70px;
   display: flex;
@@ -77,6 +79,7 @@ export const Div = styled.div`
 `;
 
 export const BottomSection = styled.section`
+  padding: 0px 20px 24px 20px;
   width: 100%;
   height: 40px;
   border-top: 1px solid #cfebff;
@@ -86,6 +89,7 @@ export const BottomSection = styled.section`
 `;
 
 export const Instargram = styled(InstargramIcon)`
+  margin-right: 16px;
   cursor: pointer;
 `;
 export const LinkedIn = styled(LinkedInIcon)`

--- a/src/style/common/HeaderStyle.tsx
+++ b/src/style/common/HeaderStyle.tsx
@@ -72,6 +72,6 @@ export const RegisterButton = styled.button`
   }
 `;
 
-export const Article = styled.span`
+export const Article = styled.p`
   color: #47484c;
 `;

--- a/src/style/projectDetail/ProjectDetailsStyle.tsx
+++ b/src/style/projectDetail/ProjectDetailsStyle.tsx
@@ -1,12 +1,13 @@
 import styled from 'styled-components';
 
-export const Main = styled.main`
-  padding: 0 170px;
+export const Main = styled.main<{ $overflow: string }>`
+  padding: 0 12vw;
   width: 100%;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
   position: relative;
+  overflow: ${({ $overflow }) => $overflow};
 `;
 export const Div = styled.div`
   width: 320px;


### PR DESCRIPTION
## refactor(#58): 프로젝트 전체보기 css 수정

## :pencil:작업 내용
- #root에 overflow-x:hidden 속성 적용 시 프로젝트 상세페이지 플로팅 박스의 position:sticky가 안 먹혀서
프로젝트 전체보기 페이지 main 태그에 overflow-x: hidden 속성 적용

- footer 좌우 padding 추가
- footer border-top 적용

- 글을 적을 때 span 태그보다 p 태그가 더 적합하다고 생각해 span 태그 p 태그로 변경