### PR TITLE
refactor(#64): 프로젝트 상세페이지 반응형 적용

### DIFF
--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -19,7 +19,7 @@ export default function Footer() {
       <s.MidSection>
         <s.Div>
           <s.DividingLine>지금.lab</s.DividingLine>
-          <span>대표 남우진</span>
+          <p>대표 남우진</p>
         </s.Div>
         <s.Div>
           <s.DividingLine>부산광역시 부산진구 동천로 116, 3층</s.DividingLine>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -16,9 +16,9 @@ export default function Header({ TopRef }: { TopRef?: React.RefObject<HTMLDivEle
             }}
           >
             <ProjectIcon />
-            <span>프로젝트</span>
+            <p>프로젝트</p>
           </s.IconBox>
-          <span>아티클</span>
+          <p>아티클</p>
         </s.Nav>
       </s.NavigationBox>
       <s.NavigationBox width={214}>

--- a/src/components/common/ShareButton.tsx
+++ b/src/components/common/ShareButton.tsx
@@ -14,7 +14,7 @@ export default function ShareButton({ width, height }: { width: number; height: 
       }}
     >
       <Share />
-      <span>공유하기</span>
+      <p>공유하기</p>
     </s.Button>
   );
 }

--- a/src/components/common/StarButon.tsx
+++ b/src/components/common/StarButon.tsx
@@ -19,8 +19,8 @@ export default function StarButton({ width, height }: { width: number; height: n
       }}
     >
       <Star />
-      <span>좋아요</span>
-      <span>{data.star}</span>
+      <p>좋아요</p>
+      <p>{data.star}</p>
     </s.Button>
   );
 }

--- a/src/components/projectDetail/FloatingBox.tsx
+++ b/src/components/projectDetail/FloatingBox.tsx
@@ -81,9 +81,9 @@ export default function FloatingBox() {
           {data.category.introduction.members.map((memberObj, index) => {
             if (index < 6) {
               if (memberObj.img == null) {
-                return <s.PersonSvg width="40" height="40" />;
+                return <s.PersonSvg width="40" height="40" key={index} />;
               } else {
-                return <s.Img src={`/public/${memberObj.img}`} alt="" />;
+                return <s.Img src={`/public/${memberObj.img}`} alt="" key={index} />;
               }
               // return <s.Img key={index} src={`/public/${memberObj.img}`} alt="" />;
             }

--- a/src/components/projectDetail/Introduction.tsx
+++ b/src/components/projectDetail/Introduction.tsx
@@ -16,8 +16,8 @@ export default function Introduction() {
           )}
           <s.Name>{memberObj.name}</s.Name>
           <s.InfoBox>
-            <span>{memberObj.role}</span>
-            <span>{memberObj.email}</span>
+            <p>{memberObj.role}</p>
+            <p>{memberObj.email}</p>
           </s.InfoBox>
           <div>
             {memberObj.profilelink.map((links, linkindex) => {

--- a/src/page/ProjectDetails.tsx
+++ b/src/page/ProjectDetails.tsx
@@ -1,4 +1,3 @@
-import { useParams } from 'react-router-dom';
 import Footer from '../components/common/Footer';
 import Header from '../components/common/Header';
 import FloatingBox from '../components/projectDetail/FloatingBox';
@@ -7,12 +6,13 @@ import ProjectIntro from '../components/projectDetail/ProjectIntro';
 import { CategoryProvider } from '../context/CategoryContext';
 import { ProjectDetailProvider } from '../context/ProjectDetailContext';
 import * as s from '../style/projectDetail/ProjectDetailsStyle';
+import { Main } from '../style/common/MainStyle';
 
 export default function ProjectDetails() {
   return (
     <>
       <Header />
-      <s.Main $overflow="none">
+      <Main $overflow="none">
         <ProjectDetailProvider>
           <CategoryProvider>
             <s.Div>
@@ -22,7 +22,7 @@ export default function ProjectDetails() {
             <ProjectDashboard />
           </CategoryProvider>
         </ProjectDetailProvider>
-      </s.Main>
+      </Main>
       <Footer />
     </>
   );

--- a/src/page/ProjectGallery.tsx
+++ b/src/page/ProjectGallery.tsx
@@ -1,19 +1,19 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import Footer from '../components/common/Footer';
 import Header from '../components/common/Header';
 import ProjectInfo from '../components/projectGallery/GalleryBanner';
 import ProjectCollection from '../components/projectGallery/ProjectCollection';
-import * as s from '../style/projectDetail/ProjectDetailsStyle';
+import { Main } from '../style/common/MainStyle';
 
 export default function ProjectGallery() {
   const TopRef = useRef<HTMLDivElement>(null);
   return (
     <>
       <Header TopRef={TopRef} />
-      <s.Main $overflow="hidden">
+      <Main $overflow="hidden">
         <ProjectInfo />
         <ProjectCollection TopRef={TopRef} />
-      </s.Main>
+      </Main>
       <Footer />
     </>
   );

--- a/src/style/common/FooterStyle.tsx
+++ b/src/style/common/FooterStyle.tsx
@@ -3,15 +3,16 @@ import { ReactComponent as InstargramIcon } from '../../assets/svg/InstargramNon
 import { ReactComponent as LinkedInIcon } from '../../assets/svg/LinkedIn.svg';
 
 export const Footer = styled.footer`
-  padding: 0 170px;
+  padding: 40px min(170px, calc(70px + ((100vw - 1200px) / 2))) 24px min(170px, calc(70px + ((100vw - 1200px) / 2)));
   width: 100%;
-  height: 292px;
   border-top: 1px solid #cfebff;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
 `;
 
 export const TopSection = styled.section`
-  padding: 40px 20px 32px 20px;
   width: 100%;
   height: 54px;
   display: flex;
@@ -19,7 +20,7 @@ export const TopSection = styled.section`
 `;
 
 export const ServiceInfo = styled.div`
-  width: 271px;
+  width: 30%;
   height: 100%;
   gap: 4px;
 
@@ -31,8 +32,9 @@ export const ServiceInfo = styled.div`
 `;
 
 export const FooterMenu = styled.div`
-  width: 381px;
+  width: 40%;
   display: flex;
+  justify-content: end;
   gap: 32px;
 
   color: #171719;
@@ -43,12 +45,11 @@ export const FooterMenu = styled.div`
   cursor: pointer;
 `;
 
-export const Menu = styled.span`
+export const Menu = styled.p`
   cursor: pointer;
 `;
 
 export const MidSection = styled.section`
-  padding: 0px 20px 32px 20px;
   width: 100%;
   height: 70px;
   display: flex;
@@ -79,7 +80,6 @@ export const Div = styled.div`
 `;
 
 export const BottomSection = styled.section`
-  padding: 0px 20px 24px 20px;
   width: 100%;
   height: 40px;
   border-top: 1px solid #cfebff;

--- a/src/style/common/HeaderStyle.tsx
+++ b/src/style/common/HeaderStyle.tsx
@@ -5,7 +5,8 @@ import { ReactComponent as RegisterIcon } from '../../assets/svg/Register.svg';
 import { ReactComponent as UserIcon } from '../../assets/svg/Person.svg';
 
 export const Header = styled.header`
-  padding: 0 170px 0 170px;
+  /* padding: 0 170px; */
+  padding: 0 min(170px, calc(70px + ((100vw - 1200px) / 2)));
   width: 100%;
   height: 66px;
   box-sizing: border-box;

--- a/src/style/common/MainStyle.tsx
+++ b/src/style/common/MainStyle.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+export const Main = styled.main<{ $overflow: string }>`
+  padding: 0 min(170px, calc(50px + ((100vw - 1200px) / 2)));
+  width: 100%;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow: ${({ $overflow }) => $overflow};
+`;

--- a/src/style/projectDetail/CarouselStyle.tsx
+++ b/src/style/projectDetail/CarouselStyle.tsx
@@ -3,7 +3,7 @@ import { ReactComponent as LeftButton } from '../../assets/svg/LeftButton.svg';
 import { ReactComponent as RightButton } from '../../assets/svg/RightButton.svg';
 
 export const Section = styled.section`
-  width: 780px;
+  width: 100%;
   height: 218px;
   position: relative;
 `;

--- a/src/style/projectDetail/ProjectDetailsStyle.tsx
+++ b/src/style/projectDetail/ProjectDetailsStyle.tsx
@@ -1,20 +1,11 @@
 import styled from 'styled-components';
 
-export const Main = styled.main<{ $overflow: string }>`
-  padding: 0 12vw;
-  width: 100%;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  position: relative;
-  overflow: ${({ $overflow }) => $overflow};
-`;
 export const Div = styled.div`
-  width: 320px;
+  width: 240px;
   height: 100%;
   display: flex;
   justify-content: center;
   position: absolute;
-  right: 10vw;
-  z-index: 4;
+  right: min(190px, calc(70px + ((100vw - 1200px) / 2)));
+  z-index: 2;
 `;

--- a/src/style/projectDetail/ProjectIntroStyle.tsx
+++ b/src/style/projectDetail/ProjectIntroStyle.tsx
@@ -1,20 +1,20 @@
 import styled from 'styled-components';
 
 export const Section = styled.section`
-  width: 1100px;
+  width: 100%;
   display: flex;
   flex-direction: column;
   position: relative;
 `;
 
 export const Banner = styled.img`
-  width: 1100px;
+  width: 100%;
   height: 160px;
   position: absolute;
 `;
 
 export const TempBanner = styled.div`
-  width: 1100px;
+  width: 100%;
   height: 160px;
   position: absolute;
   background-color: #f7f7f8;
@@ -28,7 +28,7 @@ export const IntroSection = styled.section`
   display: flex;
   flex-direction: column;
   flex: none;
-  z-index: 2;
+  z-index: 1;
 `;
 
 export const MainImg = styled.img`


### PR DESCRIPTION
## refactor(#64): 프로젝트 상세페이지 반응형 적용

## :pencil:작업 내용

- 프로젝트 상세페이지와 프로젝트 전체보기 페이지에서 main 스타일을 공유하고 있어 main css 분리
- footer, header 양쪽 padding값 calc로 화면 크기에 따라 다른값 적용
- FloatingBox 오른쪽 여백값 calc로 화면 크기에 따라 다른 값 적용
-  Projectintro 배너, Carousel 크기 단위 px에서 %로 변경

이외에...
-  footer span p로 변경
- FloatingBox key값 추가
- Projectintro z-index 값 수정